### PR TITLE
Release 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ build/
 .gradle
 local.properties
 *.iml
+.project
+.settings
 
 # BUCK
 buck-out/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ If there is any issue in the library or any related topics to this module, searc
 
 
 [pushe-react-native-doc]: http://docs.pushe.co/docs/react-native/intro
-[pushe-native-android-doc]: http://docs.pushe.co/docs/android-studio/studio-intro/
+[pushe-native-android-doc]: http://docs.pushe.co/docs/android-studio/intro/
 [pushe-native-ios-doc]: http://docs.pushe.co/docs/ios/intro/
 [repo-issues]: https://github.com/pusheco/pushe-react-native/issues

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,12 +29,15 @@ android {
 
 repositories {
     maven {
-        url "https://dl.bintray.com/pushe/plus"
+        url "https://dl.bintray.com/pushe/preview"
     }
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'co.pushe.plus:base:2.0.4'
+    implementation("co.pushe.plus:base:2.1.1-beta10") {
+        exclude(group:'co.pushe.plus', module:'rxjava')
+    }
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.9'
 }
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,9 +35,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation("co.pushe.plus:base:2.1.1-beta10") {
-        exclude(group:'co.pushe.plus', module:'rxjava')
-    }
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.9'
+    implementation("co.pushe.plus:base:2.1.1-beta10")
 }
   

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation("co.pushe.plus:base:2.1.1-beta10")
+    implementation("co.pushe.plus:base:2.1.1")
 }
   

--- a/android/src/main/java/co/pushe/plus/RNPushe.java
+++ b/android/src/main/java/co/pushe/plus/RNPushe.java
@@ -211,6 +211,7 @@ public class RNPushe extends ReactContextBaseJavaModule implements LifecycleEven
         }
     }
 
+    @Deprecated
     @ReactMethod
     public void getAndroidId(final Promise promise) {
         String androidId = Pushe.getAndroidId();
@@ -219,6 +220,16 @@ public class RNPushe extends ReactContextBaseJavaModule implements LifecycleEven
             promise.reject(new Error("Could not get androidId"));
         } else {
             promise.resolve(androidId);
+        }
+    }
+
+    @ReactMethod
+    public void getDeviceId(final Promise promise) {
+        String deviceId = Pushe.getDeviceId();
+        if (deviceId == null) {
+            promise.reject(new Error("Could not retreive deviceId. Make sure Pushe is initialized first"));
+        } else {
+            promise.resolve(deviceId);
         }
     }
 

--- a/android/src/main/java/co/pushe/plus/RNPushe.java
+++ b/android/src/main/java/co/pushe/plus/RNPushe.java
@@ -96,10 +96,16 @@ public class RNPushe extends ReactContextBaseJavaModule implements LifecycleEven
         reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
     }
 
-    @Deprecated
     @ReactMethod
-    public void initialize() {
-        // Does not do anything
+    public void initialize(final Promise promise) {
+        Pushe.initialize();
+        promise.resolve(true);
+    }
+
+    @ReactMethod
+    public void setUserConsentGiven(final Promise promise) {
+        Pushe.setUserConsentGiven();
+        promise.resolve(true);
     }
 
     @ReactMethod

--- a/android/src/main/java/co/pushe/plus/RNPushe.java
+++ b/android/src/main/java/co/pushe/plus/RNPushe.java
@@ -194,14 +194,6 @@ public class RNPushe extends ReactContextBaseJavaModule implements LifecycleEven
         
     }
 
-    @Deprecated
-    @ReactMethod
-    public void getPusheId(final Promise promise)
-    {
-        String pusheId = Pushe.getPusheId();
-        promise.resolve(pusheId);
-    }
-
     @ReactMethod
     public void getGoogleAdvertisingId(final Promise promise) {
         String googleAdvertisingId = Pushe.getGoogleAdvertisingId();

--- a/index.js
+++ b/index.js
@@ -130,18 +130,6 @@ class Pushe {
     }
 
     /**
-     * get user's pushe_id
-     * 
-     * it will return a promise.
-     * 
-     * @return {Promise<string>} Promise - if no callback passed
-     */
-    static getPusheId() {
-        if (Platform.OS === 'ios') return;
-        return RNPushe.getPusheId();
-    }
-
-    /**
      * get advertisingId
      * it will return a promise
      */

--- a/index.js
+++ b/index.js
@@ -93,6 +93,18 @@ class Pushe {
     }
 
     /**
+     * Only for apps that activate GDPR feature.
+     * Calling this means user gave consent due to GDPR rule and Pushe is allowed to work.
+     * (Calling this only once, is enough)
+     * 
+     * <b>By default this code is not needed to ba called</b>
+     */
+    static initialize() {
+        if (Platform.OS == 'ios') return;
+        return RNPushe.initialize();
+    }
+
+    /**
      * Check if Pushe is initialized or not
      *
      * it will return promise of type boolean

--- a/index.js
+++ b/index.js
@@ -150,8 +150,8 @@ class Pushe {
         return RNPushe.getGoogleAdvertisingId();
     }
     /**
-     * get androidId
-     * it will return a promise
+     * Returns androidId of device (No function in iOS)
+     * @deprecated since 2.1.1. In order to get android id, use <code>getDeviceId()</code>
      */
     static getAndroidId() {
         if (Platform.OS === 'ios') return;
@@ -383,10 +383,9 @@ class Pushe {
     }
 
     /**
-    * Returns DeviceId for iOS
+    * Returns DeviceId for iOS and Android
     */
     static getDeviceId() {
-        if (Platform.OS === 'android') return;
         return RNPushe.getDeviceId();
     }
     

--- a/index.js
+++ b/index.js
@@ -117,6 +117,14 @@ class Pushe {
     }
 
     /**
+     * Set special permission.
+     */
+    static setUserConsentGiven() {
+        if (Platform.OS == 'ios') return;
+        return RNPushe.setUserConsentGiven();
+    }
+
+    /**
      * Check if Pushe is registered or not
      * 
      * it will return promise of type boolean

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pushe-react-native",
-  "version": "2.0.1",
-  "pushe-bundled-version": "2.0.4",
+  "version": "2.1.1",
+  "pushe-bundled-version": "2.1.1",
   "description": "pushe.co plugin for react native iOS and Android platforms",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Changes
- Update native dependency to highest (Currently in beta)
- Deprecate `getAndroidId` and combine functionality with `getDeviceId`
- Un-deprecate (?) `initialize` for different use case (GDPR)

### WIP
- [x] Wait for stable release of Native dependecy to update the PR